### PR TITLE
fix: eslint rule 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unknown-property": [
+      2,
+      {
+        "ignore": ["jsx"]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
`eslint-plugin-react` version `7.31.2`부터 발생하는`styled-jsx` 태그내 인식을 못하는 lint error 수정합니다.

https://github.com/vercel/next.js/discussions/40269