### PR TITLE
fix: query client 리렌더링시 마다 새로 생성되는 부분 수정

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,11 +3,26 @@ import type { AppProps } from "next/app";
 import NavigationBar from "../components/NavigationBar";
 import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
+import { getMainLectureList } from "../api/lecture";
+import { useState } from "react";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const queryClient = new QueryClient();
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5,
+            refetchOnWindowFocus: false,
+            retry: false,
+          },
+        },
+      })
+  );
+
+  console.log("queryClient", client);
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
### AS IS

기존에는 react-query query Client 생성자 함수를 계속 호출하여 react-query cache 기능을 이용하지 못하였음

main page에서 호출한 데이터가 query client에 담겨 있었으나 search page로 이동한 뒤 새로 데이터 요청을 했을 때 
next js page 동작원리에 의해  맨처음 main page로 갔을 때 `pages/_app.tsx `가 먼저 실행되고 그 다음 main page가 렌더링 되고, search 페이지로 이동 하였을 때 pages/app.tsx 이후 `pages/search.tsx` 가 렌더링 된다. 따라서 _app.tsx는 매번 실행 되는데 이 때 마다 query Client 생성자 함수를 매번 호출하므로 매 페이지마다 새로운 client가 생성되어 제대로 caching을 하지 못함. 

<img width="482" alt="image" src="https://user-images.githubusercontent.com/60845910/192301064-05d3d131-dae2-4c99-8f22-0583ffbd00cd.png">

### TO BE

useState는 setter함수를 호출하지 않으면 initialization은 오직 state가 처음 생성될 때만 실행된다. 리렌더링 시 이 함수의 실행은 무시되므로 매번 같은 query client생성자는 라이프사이클 당 한번만 호출된다.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/60845910/192302133-c9cfb0e3-3865-4b39-8136-2a5a0d0d11ba.png">

참고 링크 
https://candle-truffle-cb3.notion.site/useState-Lazy-initialization-200ac98239fe48638ddfb91fbc9423fa
 